### PR TITLE
Populate text sensors with values from "E-label"

### DIFF
--- a/components/huawei_r4850/__init__.py
+++ b/components/huawei_r4850/__init__.py
@@ -16,12 +16,20 @@ HuaweiR4850Component = huawei_r4850_ns.class_(
     "HuaweiR4850Component", cg.PollingComponent
 )
 
+HUAWEI_R4850_COMPONENT_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_HUAWEI_R4850_ID): cv.use_id(HuaweiR4850Component),
+    }
+)
+
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(HuaweiR4850Component),
         cv.Required(CONF_CANBUS_ID): cv.use_id(CanbusComponent),
         cv.Required(CONF_PSU_ADDRESS): cv.int_range(min=1, max=127),
-        cv.Optional(CONF_PSU_MAX_CURRENT, default=63.3): cv.float_range(min=0, min_included=False),
+        cv.Optional(CONF_PSU_MAX_CURRENT, default=63.3): cv.float_range(
+            min=0, min_included=False
+        ),
         cv.Optional(CONF_RESEND_INTERVAL): cv.update_interval,
     }
 ).extend(cv.polling_component_schema("5s"))

--- a/components/huawei_r4850/huawei_r4850.cpp
+++ b/components/huawei_r4850/huawei_r4850.cpp
@@ -327,11 +327,13 @@ void HuaweiR4850Component::publish_sensor_state_(sensor::Sensor *sensor, float v
 }
 #endif
 
+#ifdef USE_TEXT_SENSOR
 void HuaweiR4850Component::publish_sensor_state_(text_sensor::TextSensor *sensor, const char *state) {
   if (sensor) {
     sensor->publish_state(state);
   }
 }
+#endif // USE_TEXT_SENSOR
 
 uint32_t HuaweiR4850Component::canid_pack_(uint8_t addr, uint8_t command, bool src_controller, bool incomplete) {
   uint32_t id = 0x1080007E; // proto ID, group mask, HW/SW id flag already set

--- a/components/huawei_r4850/huawei_r4850.cpp
+++ b/components/huawei_r4850/huawei_r4850.cpp
@@ -299,6 +299,7 @@ void HuaweiR4850Component::on_frame(uint32_t can_id, bool extended_id, bool rtr,
     if (!incomplete) {
       ESP_LOGI(TAG, "E-Label response received, populating sensors");
       ELabelResponse elabel_response = parse_elabel_response(raw_elabel_response);
+      raw_elabel_response.clear();
 
       std::map<std::string, text_sensor::TextSensor*> sensor_mappings = {
         {"BoardType", board_type_text_sensor_},

--- a/components/huawei_r4850/huawei_r4850.h
+++ b/components/huawei_r4850/huawei_r4850.h
@@ -5,6 +5,7 @@
 #ifdef USE_SENSOR
 #include "esphome/components/sensor/sensor.h"
 #endif
+#include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/canbus/canbus.h"
 
 namespace esphome {
@@ -61,6 +62,21 @@ class HuaweiR4850Component : public PollingComponent {
     needs_fan_status_ = true;
   }
 #endif // USE_SENSOR
+  void set_board_type_text_sensor(text_sensor::TextSensor *board_type_text_sensor) {
+    board_type_text_sensor_ = board_type_text_sensor;
+  }
+
+  void set_serial_number_text_sensor(text_sensor::TextSensor *serial_number_text_sensor) {
+    serial_number_text_sensor_ = serial_number_text_sensor;
+  }
+
+  void set_item_text_sensor(text_sensor::TextSensor *info_text_sensor) {
+    item_text_sensor_ = info_text_sensor;
+  }
+
+  void set_model_text_sensor(text_sensor::TextSensor *model_text_sensor) {
+    model_text_sensor_ = model_text_sensor;
+  }
 
   void register_input(HuaweiR4850Input *number) {
     this->registered_inputs_.push_back(number);
@@ -87,6 +103,9 @@ class HuaweiR4850Component : public PollingComponent {
   float psu_max_current_;
   uint8_t psu_addr_;
 
+  bool has_received_elabel_response_ = false;
+  std::string raw_elabel_response;
+
 #ifdef USE_SENSOR
   sensor::Sensor *input_voltage_sensor_{nullptr};
   sensor::Sensor *input_frequency_sensor_{nullptr};
@@ -105,6 +124,12 @@ class HuaweiR4850Component : public PollingComponent {
   bool needs_fan_status_{0};
   void publish_sensor_state_(sensor::Sensor *sensor, float value);
 #endif // USE_SENSOR
+  void publish_sensor_state_(text_sensor::TextSensor *sensor, const char *state);
+
+  text_sensor::TextSensor *board_type_text_sensor_{nullptr};
+  text_sensor::TextSensor *serial_number_text_sensor_{nullptr};
+  text_sensor::TextSensor *item_text_sensor_{nullptr};
+  text_sensor::TextSensor *model_text_sensor_{nullptr};
 
   std::vector<HuaweiR4850Input *> registered_inputs_{};
 

--- a/components/huawei_r4850/huawei_r4850.h
+++ b/components/huawei_r4850/huawei_r4850.h
@@ -48,15 +48,15 @@ class HuaweiR4850Component : public PollingComponent {
   void set_output_power_sensor(sensor::Sensor *output_power_sensor) { output_power_sensor_ = output_power_sensor; }
   void set_output_temp_sensor(sensor::Sensor *output_temp_sensor) { output_temp_sensor_ = output_temp_sensor; }
 
-  void set_fan_duty_cycle_min_sensor(sensor::Sensor *fan_duty_cycle_min_sensor) { 
-    fan_duty_cycle_min_sensor_ = fan_duty_cycle_min_sensor; 
+  void set_fan_duty_cycle_min_sensor(sensor::Sensor *fan_duty_cycle_min_sensor) {
+    fan_duty_cycle_min_sensor_ = fan_duty_cycle_min_sensor;
     needs_fan_status_ = true;
   }
-  void set_fan_duty_cycle_target_sensor(sensor::Sensor *fan_duty_cycle_target_sensor) { 
-    fan_duty_cycle_target_sensor_ = fan_duty_cycle_target_sensor; 
+  void set_fan_duty_cycle_target_sensor(sensor::Sensor *fan_duty_cycle_target_sensor) {
+    fan_duty_cycle_target_sensor_ = fan_duty_cycle_target_sensor;
     needs_fan_status_ = true;
   }
-  void set_fan_rpm_sensor(sensor::Sensor *fan_rpm_sensor) { 
+  void set_fan_rpm_sensor(sensor::Sensor *fan_rpm_sensor) {
     fan_rpm_sensor_ = fan_rpm_sensor;
     needs_fan_status_ = true;
   }

--- a/components/huawei_r4850/huawei_r4850.h
+++ b/components/huawei_r4850/huawei_r4850.h
@@ -62,6 +62,8 @@ class HuaweiR4850Component : public PollingComponent {
     needs_fan_status_ = true;
   }
 #endif // USE_SENSOR
+
+#ifdef USE_TEXT_SENSOR
   void set_board_type_text_sensor(text_sensor::TextSensor *board_type_text_sensor) {
     board_type_text_sensor_ = board_type_text_sensor;
   }
@@ -77,6 +79,7 @@ class HuaweiR4850Component : public PollingComponent {
   void set_model_text_sensor(text_sensor::TextSensor *model_text_sensor) {
     model_text_sensor_ = model_text_sensor;
   }
+#endif // USE_TEXT_SENSOR
 
   void register_input(HuaweiR4850Input *number) {
     this->registered_inputs_.push_back(number);
@@ -124,12 +127,15 @@ class HuaweiR4850Component : public PollingComponent {
   bool needs_fan_status_{0};
   void publish_sensor_state_(sensor::Sensor *sensor, float value);
 #endif // USE_SENSOR
+
+#ifdef USE_TEXT_SENSOR
   void publish_sensor_state_(text_sensor::TextSensor *sensor, const char *state);
 
   text_sensor::TextSensor *board_type_text_sensor_{nullptr};
   text_sensor::TextSensor *serial_number_text_sensor_{nullptr};
   text_sensor::TextSensor *item_text_sensor_{nullptr};
   text_sensor::TextSensor *model_text_sensor_{nullptr};
+#endif // USE_TEXT_SENSOR
 
   std::vector<HuaweiR4850Input *> registered_inputs_{};
 

--- a/components/huawei_r4850/number/__init__.py
+++ b/components/huawei_r4850/number/__init__.py
@@ -1,23 +1,23 @@
 import esphome.codegen as cg
-import esphome.config_validation as cv
 from esphome.components import number
+import esphome.config_validation as cv
 from esphome.const import (
-    UNIT_VOLT,
-    UNIT_AMPERE,
-    UNIT_PERCENT,
     CONF_ID,
+    CONF_MAX_VALUE,
+    CONF_MIN_VALUE,
     CONF_MODE,
+    CONF_RESTORE_VALUE,
+    CONF_STEP,
     DEVICE_CLASS_CURRENT,
     DEVICE_CLASS_VOLTAGE,
     ICON_CURRENT_AC,
     ICON_FAN,
-    CONF_MIN_VALUE,
-    CONF_MAX_VALUE,
-    CONF_STEP,
-    CONF_RESTORE_VALUE,
+    UNIT_AMPERE,
+    UNIT_PERCENT,
+    UNIT_VOLT,
 )
 
-from .. import HuaweiR4850Component, huawei_r4850_ns, CONF_HUAWEI_R4850_ID
+from .. import CONF_HUAWEI_R4850_ID, HUAWEI_R4850_COMPONENT_SCHEMA, huawei_r4850_ns
 
 ICON_CURRENT_DC = "mdi:current-dc"
 
@@ -32,93 +32,102 @@ HuaweiR4850Number = huawei_r4850_ns.class_(
     "HuaweiR4850Number", number.Number, cg.Component
 )
 
-CONFIG_SCHEMA = cv.All(
-    cv.Schema(
-        {
-            cv.GenerateID(CONF_HUAWEI_R4850_ID): cv.use_id(HuaweiR4850Component),
-            cv.Optional(CONF_OUTPUT_VOLTAGE): number.number_schema(
-                HuaweiR4850Number,
-                device_class=DEVICE_CLASS_VOLTAGE,
-                unit_of_measurement=UNIT_VOLT
-            ).extend(
-                {
-                    cv.Optional(CONF_MIN_VALUE, default=41.0): cv.float_,
-                    cv.Optional(CONF_MAX_VALUE, default=58.6): cv.float_,
-                    cv.Optional(CONF_STEP, default=0.1): cv.float_,
-                    cv.Optional(CONF_MODE, default="BOX"): cv.enum(number.NUMBER_MODES, upper=True),
-                    cv.Optional(CONF_RESTORE_VALUE, default=False): cv.boolean,
-                }
-            ),
-            cv.Optional(CONF_OUTPUT_VOLTAGE_DEFAULT): number.number_schema(
-                HuaweiR4850Number,
-                device_class=DEVICE_CLASS_VOLTAGE,
-                unit_of_measurement=UNIT_VOLT
-            ).extend(
-                {
-                    cv.Optional(CONF_MIN_VALUE, default=48.0): cv.float_,
-                    cv.Optional(CONF_MAX_VALUE, default=58.4): cv.float_,
-                    cv.Optional(CONF_STEP, default=0.1): cv.float_,
-                    cv.Optional(CONF_MODE, default="BOX"): cv.enum(number.NUMBER_MODES, upper=True),
-                    cv.Optional(CONF_RESTORE_VALUE, default=False): cv.boolean,
-                }
-            ),
-            cv.Optional(CONF_MAX_OUTPUT_CURRENT): number.number_schema(
-                HuaweiR4850Number,
-                icon=ICON_CURRENT_DC,
-                device_class=DEVICE_CLASS_CURRENT,
-                unit_of_measurement=UNIT_AMPERE
-            ).extend(
-                {
-                    cv.Optional(CONF_MIN_VALUE, default=0.0): cv.float_,
-                    cv.Optional(CONF_MAX_VALUE, default=63.3): cv.float_,
-                    cv.Optional(CONF_STEP, default=0.1): cv.float_,
-                    cv.Optional(CONF_MODE, default="BOX"): cv.enum(number.NUMBER_MODES, upper=True),
-                    cv.Optional(CONF_RESTORE_VALUE, default=False): cv.boolean,
-                }
-            ),
-            cv.Optional(CONF_MAX_OUTPUT_CURRENT_DEFAULT): number.number_schema(
-                HuaweiR4850Number,
-                icon=ICON_CURRENT_DC,
-                device_class=DEVICE_CLASS_CURRENT,
-                unit_of_measurement=UNIT_AMPERE
-            ).extend(
-                {
-                    cv.Optional(CONF_MIN_VALUE, default=0.0): cv.float_,
-                    cv.Optional(CONF_MAX_VALUE, default=63.3): cv.float_,
-                    cv.Optional(CONF_STEP, default=0.1): cv.float_,
-                    cv.Optional(CONF_MODE, default="BOX"): cv.enum(number.NUMBER_MODES, upper=True),
-                    cv.Optional(CONF_RESTORE_VALUE, default=False): cv.boolean,
-                }
-            ),
-            cv.Optional(CONF_MAX_AC_CURRENT): number.number_schema(
-                HuaweiR4850Number,
-                icon=ICON_CURRENT_AC,
-                device_class=DEVICE_CLASS_CURRENT,
-                unit_of_measurement=UNIT_AMPERE
-            ).extend(
-                {
-                    cv.Optional(CONF_MIN_VALUE, default=0): cv.float_,
-                    cv.Optional(CONF_MAX_VALUE, default=20): cv.float_,
-                    cv.Optional(CONF_STEP, default=0.1): cv.float_,
-                    cv.Optional(CONF_MODE, default="BOX"): cv.enum(number.NUMBER_MODES, upper=True),
-                    cv.Optional(CONF_RESTORE_VALUE, default=False): cv.boolean,
-                }
-            ),
-            cv.Optional(CONF_FAN_DUTY_CYCLE): number.number_schema(
-                HuaweiR4850Number,
-                icon=ICON_FAN,
-                unit_of_measurement=UNIT_PERCENT
-            ).extend(
-                {
-                    cv.Optional(CONF_MIN_VALUE, default=0): cv.float_range(min=0, max=100),
-                    cv.Optional(CONF_MAX_VALUE, default=100): cv.float_range(min=0, max=100),
-                    cv.Optional(CONF_STEP, default=1): cv.float_,
-                    cv.Optional(CONF_MODE, default="SLIDER"): cv.enum(number.NUMBER_MODES, upper=True),
-                    cv.Optional(CONF_RESTORE_VALUE, default=False): cv.boolean,
-                }
-            ),
-        }
-    ).extend(cv.COMPONENT_SCHEMA)
+CONFIG_SCHEMA = HUAWEI_R4850_COMPONENT_SCHEMA.extend(
+    {
+        cv.Optional(CONF_OUTPUT_VOLTAGE): number.number_schema(
+            HuaweiR4850Number,
+            device_class=DEVICE_CLASS_VOLTAGE,
+            unit_of_measurement=UNIT_VOLT,
+        ).extend(
+            {
+                cv.Optional(CONF_MIN_VALUE, default=41.0): cv.float_,
+                cv.Optional(CONF_MAX_VALUE, default=58.6): cv.float_,
+                cv.Optional(CONF_STEP, default=0.1): cv.float_,
+                cv.Optional(CONF_MODE, default="BOX"): cv.enum(
+                    number.NUMBER_MODES, upper=True
+                ),
+                cv.Optional(CONF_RESTORE_VALUE, default=False): cv.boolean,
+            }
+        ),
+        cv.Optional(CONF_OUTPUT_VOLTAGE_DEFAULT): number.number_schema(
+            HuaweiR4850Number,
+            device_class=DEVICE_CLASS_VOLTAGE,
+            unit_of_measurement=UNIT_VOLT,
+        ).extend(
+            {
+                cv.Optional(CONF_MIN_VALUE, default=48.0): cv.float_,
+                cv.Optional(CONF_MAX_VALUE, default=58.4): cv.float_,
+                cv.Optional(CONF_STEP, default=0.1): cv.float_,
+                cv.Optional(CONF_MODE, default="BOX"): cv.enum(
+                    number.NUMBER_MODES, upper=True
+                ),
+                cv.Optional(CONF_RESTORE_VALUE, default=False): cv.boolean,
+            }
+        ),
+        cv.Optional(CONF_MAX_OUTPUT_CURRENT): number.number_schema(
+            HuaweiR4850Number,
+            icon=ICON_CURRENT_DC,
+            device_class=DEVICE_CLASS_CURRENT,
+            unit_of_measurement=UNIT_AMPERE,
+        ).extend(
+            {
+                cv.Optional(CONF_MIN_VALUE, default=0.0): cv.float_,
+                cv.Optional(CONF_MAX_VALUE, default=63.3): cv.float_,
+                cv.Optional(CONF_STEP, default=0.1): cv.float_,
+                cv.Optional(CONF_MODE, default="BOX"): cv.enum(
+                    number.NUMBER_MODES, upper=True
+                ),
+                cv.Optional(CONF_RESTORE_VALUE, default=False): cv.boolean,
+            }
+        ),
+        cv.Optional(CONF_MAX_OUTPUT_CURRENT_DEFAULT): number.number_schema(
+            HuaweiR4850Number,
+            icon=ICON_CURRENT_DC,
+            device_class=DEVICE_CLASS_CURRENT,
+            unit_of_measurement=UNIT_AMPERE,
+        ).extend(
+            {
+                cv.Optional(CONF_MIN_VALUE, default=0.0): cv.float_,
+                cv.Optional(CONF_MAX_VALUE, default=63.3): cv.float_,
+                cv.Optional(CONF_STEP, default=0.1): cv.float_,
+                cv.Optional(CONF_MODE, default="BOX"): cv.enum(
+                    number.NUMBER_MODES, upper=True
+                ),
+                cv.Optional(CONF_RESTORE_VALUE, default=False): cv.boolean,
+            }
+        ),
+        cv.Optional(CONF_MAX_AC_CURRENT): number.number_schema(
+            HuaweiR4850Number,
+            icon=ICON_CURRENT_AC,
+            device_class=DEVICE_CLASS_CURRENT,
+            unit_of_measurement=UNIT_AMPERE,
+        ).extend(
+            {
+                cv.Optional(CONF_MIN_VALUE, default=0): cv.float_,
+                cv.Optional(CONF_MAX_VALUE, default=20): cv.float_,
+                cv.Optional(CONF_STEP, default=0.1): cv.float_,
+                cv.Optional(CONF_MODE, default="BOX"): cv.enum(
+                    number.NUMBER_MODES, upper=True
+                ),
+                cv.Optional(CONF_RESTORE_VALUE, default=False): cv.boolean,
+            }
+        ),
+        cv.Optional(CONF_FAN_DUTY_CYCLE): number.number_schema(
+            HuaweiR4850Number, icon=ICON_FAN, unit_of_measurement=UNIT_PERCENT
+        ).extend(
+            {
+                cv.Optional(CONF_MIN_VALUE, default=0): cv.float_range(min=0, max=100),
+                cv.Optional(CONF_MAX_VALUE, default=100): cv.float_range(
+                    min=0, max=100
+                ),
+                cv.Optional(CONF_STEP, default=1): cv.float_,
+                cv.Optional(CONF_MODE, default="SLIDER"): cv.enum(
+                    number.NUMBER_MODES, upper=True
+                ),
+                cv.Optional(CONF_RESTORE_VALUE, default=False): cv.boolean,
+            }
+        ),
+    }
 )
 
 

--- a/components/huawei_r4850/sensor.py
+++ b/components/huawei_r4850/sensor.py
@@ -1,25 +1,26 @@
 import esphome.codegen as cg
-import esphome.config_validation as cv
 from esphome.components import sensor
+import esphome.config_validation as cv
 from esphome.const import (
-    DEVICE_CLASS_VOLTAGE,
     DEVICE_CLASS_CURRENT,
-    DEVICE_CLASS_TEMPERATURE,
     DEVICE_CLASS_FREQUENCY,
     DEVICE_CLASS_POWER,
-    STATE_CLASS_MEASUREMENT,
-    UNIT_VOLT,
-    UNIT_HERTZ,
-    UNIT_AMPERE,
-    UNIT_PERCENT,
-    UNIT_CELSIUS,
-    UNIT_WATT,
-    UNIT_REVOLUTIONS_PER_MINUTE,
-    ICON_PERCENT,
+    DEVICE_CLASS_TEMPERATURE,
+    DEVICE_CLASS_VOLTAGE,
     ICON_CURRENT_AC,
     ICON_FAN,
+    ICON_PERCENT,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_AMPERE,
+    UNIT_CELSIUS,
+    UNIT_HERTZ,
+    UNIT_PERCENT,
+    UNIT_REVOLUTIONS_PER_MINUTE,
+    UNIT_VOLT,
+    UNIT_WATT,
 )
-from . import HuaweiR4850Component, CONF_HUAWEI_R4850_ID
+
+from . import CONF_HUAWEI_R4850_ID, HUAWEI_R4850_COMPONENT_SCHEMA
 
 ICON_CURRENT_DC = "mdi:current-dc"
 
@@ -55,100 +56,96 @@ TYPES = [
     CONF_FAN_RPM,
 ]
 
-
-CONFIG_SCHEMA = cv.All(
-    cv.Schema(
-        {
-            cv.GenerateID(CONF_HUAWEI_R4850_ID): cv.use_id(HuaweiR4850Component),
-            cv.Optional(CONF_INPUT_VOLTAGE): sensor.sensor_schema(
-                unit_of_measurement=UNIT_VOLT,
-                accuracy_decimals=1,
-                device_class=DEVICE_CLASS_VOLTAGE,
-                state_class=STATE_CLASS_MEASUREMENT,
-            ),
-            cv.Optional(CONF_INPUT_FREQUENCY): sensor.sensor_schema(
-                unit_of_measurement=UNIT_HERTZ,
-                accuracy_decimals=2,
-                device_class=DEVICE_CLASS_FREQUENCY,
-                state_class=STATE_CLASS_MEASUREMENT,
-            ),
-            cv.Optional(CONF_INPUT_CURRENT): sensor.sensor_schema(
-                unit_of_measurement=UNIT_AMPERE,
-                icon=ICON_CURRENT_AC,
-                accuracy_decimals=2,
-                device_class=DEVICE_CLASS_CURRENT,
-                state_class=STATE_CLASS_MEASUREMENT,
-            ),
-            cv.Optional(CONF_INPUT_POWER): sensor.sensor_schema(
-                unit_of_measurement=UNIT_WATT,
-                accuracy_decimals=1,
-                device_class=DEVICE_CLASS_POWER,
-                state_class=STATE_CLASS_MEASUREMENT,
-            ),
-            cv.Optional(CONF_INPUT_TEMP): sensor.sensor_schema(
-                unit_of_measurement=UNIT_CELSIUS,
-                accuracy_decimals=1,
-                device_class=DEVICE_CLASS_TEMPERATURE,
-                state_class=STATE_CLASS_MEASUREMENT,
-            ),
-            cv.Optional(CONF_EFFICIENCY): sensor.sensor_schema(
-                unit_of_measurement=UNIT_PERCENT,
-                icon=ICON_PERCENT,
-                accuracy_decimals=0,
-                state_class=STATE_CLASS_MEASUREMENT,
-            ),
-            cv.Optional(CONF_OUTPUT_VOLTAGE): sensor.sensor_schema(
-                unit_of_measurement=UNIT_VOLT,
-                accuracy_decimals=2,
-                device_class=DEVICE_CLASS_VOLTAGE,
-                state_class=STATE_CLASS_MEASUREMENT,
-            ),
-            cv.Optional(CONF_OUTPUT_CURRENT): sensor.sensor_schema(
-                unit_of_measurement=UNIT_AMPERE,
-                icon=ICON_CURRENT_DC,
-                accuracy_decimals=2,
-                device_class=DEVICE_CLASS_CURRENT,
-                state_class=STATE_CLASS_MEASUREMENT,
-            ),
-            cv.Optional(CONF_OUTPUT_CURRENT_SETPOINT): sensor.sensor_schema(
-                unit_of_measurement=UNIT_AMPERE,
-                icon=ICON_CURRENT_DC,
-                accuracy_decimals=2,
-                device_class=DEVICE_CLASS_CURRENT,
-                state_class=STATE_CLASS_MEASUREMENT,
-            ),
-            cv.Optional(CONF_OUTPUT_POWER): sensor.sensor_schema(
-                unit_of_measurement=UNIT_WATT,
-                accuracy_decimals=1,
-                device_class=DEVICE_CLASS_POWER,
-                state_class=STATE_CLASS_MEASUREMENT,
-            ),
-            cv.Optional(CONF_OUTPUT_TEMP): sensor.sensor_schema(
-                unit_of_measurement=UNIT_CELSIUS,
-                accuracy_decimals=1,
-                device_class=DEVICE_CLASS_TEMPERATURE,
-                state_class=STATE_CLASS_MEASUREMENT,
-            ),
-            cv.Optional(CONF_FAN_DUTY_CYCLE_MIN): sensor.sensor_schema(
-                unit_of_measurement=UNIT_PERCENT,
-                icon=ICON_FAN,
-                accuracy_decimals=0,
-                state_class=STATE_CLASS_MEASUREMENT,
-            ),
-            cv.Optional(CONF_FAN_DUTY_CYCLE_TARGET): sensor.sensor_schema(
-                unit_of_measurement=UNIT_PERCENT,
-                icon=ICON_FAN,
-                accuracy_decimals=0,
-                state_class=STATE_CLASS_MEASUREMENT,
-            ),
-            cv.Optional(CONF_FAN_RPM): sensor.sensor_schema(
-                unit_of_measurement=UNIT_REVOLUTIONS_PER_MINUTE,
-                icon=ICON_FAN,
-                accuracy_decimals=0,
-                state_class=STATE_CLASS_MEASUREMENT,
-            ),
-        }
-    ).extend(cv.COMPONENT_SCHEMA)
+CONFIG_SCHEMA = HUAWEI_R4850_COMPONENT_SCHEMA.extend(
+    {
+        cv.Optional(CONF_INPUT_VOLTAGE): sensor.sensor_schema(
+            unit_of_measurement=UNIT_VOLT,
+            accuracy_decimals=1,
+            device_class=DEVICE_CLASS_VOLTAGE,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional(CONF_INPUT_FREQUENCY): sensor.sensor_schema(
+            unit_of_measurement=UNIT_HERTZ,
+            accuracy_decimals=2,
+            device_class=DEVICE_CLASS_FREQUENCY,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional(CONF_INPUT_CURRENT): sensor.sensor_schema(
+            unit_of_measurement=UNIT_AMPERE,
+            icon=ICON_CURRENT_AC,
+            accuracy_decimals=2,
+            device_class=DEVICE_CLASS_CURRENT,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional(CONF_INPUT_POWER): sensor.sensor_schema(
+            unit_of_measurement=UNIT_WATT,
+            accuracy_decimals=1,
+            device_class=DEVICE_CLASS_POWER,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional(CONF_INPUT_TEMP): sensor.sensor_schema(
+            unit_of_measurement=UNIT_CELSIUS,
+            accuracy_decimals=1,
+            device_class=DEVICE_CLASS_TEMPERATURE,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional(CONF_EFFICIENCY): sensor.sensor_schema(
+            unit_of_measurement=UNIT_PERCENT,
+            icon=ICON_PERCENT,
+            accuracy_decimals=0,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional(CONF_OUTPUT_VOLTAGE): sensor.sensor_schema(
+            unit_of_measurement=UNIT_VOLT,
+            accuracy_decimals=2,
+            device_class=DEVICE_CLASS_VOLTAGE,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional(CONF_OUTPUT_CURRENT): sensor.sensor_schema(
+            unit_of_measurement=UNIT_AMPERE,
+            icon=ICON_CURRENT_DC,
+            accuracy_decimals=2,
+            device_class=DEVICE_CLASS_CURRENT,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional(CONF_OUTPUT_CURRENT_SETPOINT): sensor.sensor_schema(
+            unit_of_measurement=UNIT_AMPERE,
+            icon=ICON_CURRENT_DC,
+            accuracy_decimals=2,
+            device_class=DEVICE_CLASS_CURRENT,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional(CONF_OUTPUT_POWER): sensor.sensor_schema(
+            unit_of_measurement=UNIT_WATT,
+            accuracy_decimals=1,
+            device_class=DEVICE_CLASS_POWER,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional(CONF_OUTPUT_TEMP): sensor.sensor_schema(
+            unit_of_measurement=UNIT_CELSIUS,
+            accuracy_decimals=1,
+            device_class=DEVICE_CLASS_TEMPERATURE,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional(CONF_FAN_DUTY_CYCLE_MIN): sensor.sensor_schema(
+            unit_of_measurement=UNIT_PERCENT,
+            icon=ICON_FAN,
+            accuracy_decimals=0,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional(CONF_FAN_DUTY_CYCLE_TARGET): sensor.sensor_schema(
+            unit_of_measurement=UNIT_PERCENT,
+            icon=ICON_FAN,
+            accuracy_decimals=0,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional(CONF_FAN_RPM): sensor.sensor_schema(
+            unit_of_measurement=UNIT_REVOLUTIONS_PER_MINUTE,
+            icon=ICON_FAN,
+            accuracy_decimals=0,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+    }
 )
 
 

--- a/components/huawei_r4850/switch/__init__.py
+++ b/components/huawei_r4850/switch/__init__.py
@@ -1,15 +1,9 @@
 import esphome.codegen as cg
-import esphome.config_validation as cv
 from esphome.components import switch
-from esphome.const import (
-    CONF_ID,
-    CONF_RESTORE_VALUE,
-    ICON_FAN,
-    ICON_POWER,
-)
+import esphome.config_validation as cv
+from esphome.const import CONF_ID, CONF_RESTORE_VALUE, ICON_FAN, ICON_POWER
 
-from .. import HuaweiR4850Component, huawei_r4850_ns, CONF_HUAWEI_R4850_ID
-
+from .. import CONF_HUAWEI_R4850_ID, HUAWEI_R4850_COMPONENT_SCHEMA, huawei_r4850_ns
 
 CONF_FAN_SPEED_MAX = "fan_speed_max"
 CONF_STANDBY = "standby"
@@ -18,22 +12,23 @@ HuaweiR4850Switch = huawei_r4850_ns.class_(
     "HuaweiR4850Switch", switch.Switch, cg.Component
 )
 
-CONFIG_SCHEMA = cv.All(
-    cv.Schema(
-        {
-            cv.GenerateID(CONF_HUAWEI_R4850_ID): cv.use_id(HuaweiR4850Component),
-            cv.Optional(CONF_FAN_SPEED_MAX): switch.switch_schema(HuaweiR4850Switch, icon=ICON_FAN).extend(
-                {
-                    cv.Optional(CONF_RESTORE_VALUE, default=False): cv.boolean,
-                }
-            ),
-            cv.Optional(CONF_STANDBY): switch.switch_schema(HuaweiR4850Switch, icon=ICON_POWER).extend(
-                {
-                    cv.Optional(CONF_RESTORE_VALUE, default=False): cv.boolean,
-                }
-            ),
-        }
-    ).extend(cv.COMPONENT_SCHEMA)
+CONFIG_SCHEMA = HUAWEI_R4850_COMPONENT_SCHEMA.extend(
+    {
+        cv.Optional(CONF_FAN_SPEED_MAX): switch.switch_schema(
+            HuaweiR4850Switch, icon=ICON_FAN
+        ).extend(
+            {
+                cv.Optional(CONF_RESTORE_VALUE, default=False): cv.boolean,
+            }
+        ),
+        cv.Optional(CONF_STANDBY): switch.switch_schema(
+            HuaweiR4850Switch, icon=ICON_POWER
+        ).extend(
+            {
+                cv.Optional(CONF_RESTORE_VALUE, default=False): cv.boolean,
+            }
+        ),
+    }
 )
 
 

--- a/components/huawei_r4850/text_sensor.py
+++ b/components/huawei_r4850/text_sensor.py
@@ -1,0 +1,42 @@
+import esphome.codegen as cg
+from esphome.components import text_sensor
+import esphome.config_validation as cv
+from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC
+
+from . import CONF_HUAWEI_R4850_ID, HUAWEI_R4850_COMPONENT_SCHEMA
+
+CONF_BOARD_TYPE = "board_type"
+CONF_SERIAL_NUMBER = "serial_number"
+CONF_ITEM = "item"
+CONF_MODEL = "model"
+
+TEXT_SENSORS = {
+    CONF_BOARD_TYPE: text_sensor.text_sensor_schema(
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+    CONF_SERIAL_NUMBER: text_sensor.text_sensor_schema(
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+    CONF_ITEM: text_sensor.text_sensor_schema(
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+    CONF_MODEL: text_sensor.text_sensor_schema(
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+}
+
+CONFIG_SCHEMA = HUAWEI_R4850_COMPONENT_SCHEMA.extend(
+    {
+        cv.Optional(sensor_name): sensor_config
+        for sensor_name, sensor_config in TEXT_SENSORS.items()
+    }
+)
+
+
+async def to_code(config):
+    hub = await cg.get_variable(config[CONF_HUAWEI_R4850_ID])
+    for sensor_name in TEXT_SENSORS:
+        if sensor_name in config:
+            conf = config[sensor_name]
+            sens = await text_sensor.new_text_sensor(conf)
+            cg.add(getattr(hub, f"set_{sensor_name}_text_sensor")(sens))


### PR DESCRIPTION
```
[19:27:17.281][I][huawei_r4850:299]: E-Label response received, populating sensors
[19:27:17.285][D][text_sensor:113]: 'Serial number' >> 'BT2440636718'
[19:27:17.287][D][text_sensor:113]: 'Board type' >> 'EN1MRF7G1A5'
[19:27:17.287][D][text_sensor:113]: 'Item' >> '02312NFE-002'
[19:27:17.288][D][text_sensor:113]: 'Model' >> 'R4875G5'
```

I'm building a three-phase charger and I want to be able to know which of the configured units is which (physically).

Now that this value is available it would also be possible to specify instances using the serial number instead of the PSU address, and have the component automatically determine the PSU address based on the received board information. But that will only be needed if it turns out that the PSU address assignment is non-deterministic.