### PR TITLE
Use "config" entity category for configurable values

### DIFF
--- a/components/huawei_r4850/number/__init__.py
+++ b/components/huawei_r4850/number/__init__.py
@@ -10,6 +10,7 @@ from esphome.const import (
     CONF_STEP,
     DEVICE_CLASS_CURRENT,
     DEVICE_CLASS_VOLTAGE,
+    ENTITY_CATEGORY_CONFIG,
     ICON_CURRENT_AC,
     ICON_FAN,
     UNIT_AMPERE,
@@ -37,6 +38,7 @@ CONFIG_SCHEMA = HUAWEI_R4850_COMPONENT_SCHEMA.extend(
         cv.Optional(CONF_OUTPUT_VOLTAGE): number.number_schema(
             HuaweiR4850Number,
             device_class=DEVICE_CLASS_VOLTAGE,
+            entity_category=ENTITY_CATEGORY_CONFIG,
             unit_of_measurement=UNIT_VOLT,
         ).extend(
             {
@@ -52,6 +54,7 @@ CONFIG_SCHEMA = HUAWEI_R4850_COMPONENT_SCHEMA.extend(
         cv.Optional(CONF_OUTPUT_VOLTAGE_DEFAULT): number.number_schema(
             HuaweiR4850Number,
             device_class=DEVICE_CLASS_VOLTAGE,
+            entity_category=ENTITY_CATEGORY_CONFIG,
             unit_of_measurement=UNIT_VOLT,
         ).extend(
             {
@@ -68,6 +71,7 @@ CONFIG_SCHEMA = HUAWEI_R4850_COMPONENT_SCHEMA.extend(
             HuaweiR4850Number,
             icon=ICON_CURRENT_DC,
             device_class=DEVICE_CLASS_CURRENT,
+            entity_category=ENTITY_CATEGORY_CONFIG,
             unit_of_measurement=UNIT_AMPERE,
         ).extend(
             {
@@ -84,6 +88,7 @@ CONFIG_SCHEMA = HUAWEI_R4850_COMPONENT_SCHEMA.extend(
             HuaweiR4850Number,
             icon=ICON_CURRENT_DC,
             device_class=DEVICE_CLASS_CURRENT,
+            entity_category=ENTITY_CATEGORY_CONFIG,
             unit_of_measurement=UNIT_AMPERE,
         ).extend(
             {
@@ -100,6 +105,7 @@ CONFIG_SCHEMA = HUAWEI_R4850_COMPONENT_SCHEMA.extend(
             HuaweiR4850Number,
             icon=ICON_CURRENT_AC,
             device_class=DEVICE_CLASS_CURRENT,
+            entity_category=ENTITY_CATEGORY_CONFIG,
             unit_of_measurement=UNIT_AMPERE,
         ).extend(
             {
@@ -113,7 +119,10 @@ CONFIG_SCHEMA = HUAWEI_R4850_COMPONENT_SCHEMA.extend(
             }
         ),
         cv.Optional(CONF_FAN_DUTY_CYCLE): number.number_schema(
-            HuaweiR4850Number, icon=ICON_FAN, unit_of_measurement=UNIT_PERCENT
+            HuaweiR4850Number,
+            icon=ICON_FAN,
+            entity_category=ENTITY_CATEGORY_CONFIG,
+            unit_of_measurement=UNIT_PERCENT,
         ).extend(
             {
                 cv.Optional(CONF_MIN_VALUE, default=0): cv.float_range(min=0, max=100),

--- a/components/huawei_r4850/switch/__init__.py
+++ b/components/huawei_r4850/switch/__init__.py
@@ -1,7 +1,13 @@
 import esphome.codegen as cg
 from esphome.components import switch
 import esphome.config_validation as cv
-from esphome.const import CONF_ID, CONF_RESTORE_VALUE, ICON_FAN, ICON_POWER
+from esphome.const import (
+    CONF_ID,
+    CONF_RESTORE_VALUE,
+    ENTITY_CATEGORY_CONFIG,
+    ICON_FAN,
+    ICON_POWER,
+)
 
 from .. import CONF_HUAWEI_R4850_ID, HUAWEI_R4850_COMPONENT_SCHEMA, huawei_r4850_ns
 
@@ -15,14 +21,14 @@ HuaweiR4850Switch = huawei_r4850_ns.class_(
 CONFIG_SCHEMA = HUAWEI_R4850_COMPONENT_SCHEMA.extend(
     {
         cv.Optional(CONF_FAN_SPEED_MAX): switch.switch_schema(
-            HuaweiR4850Switch, icon=ICON_FAN
+            HuaweiR4850Switch, icon=ICON_FAN, entity_category=ENTITY_CATEGORY_CONFIG
         ).extend(
             {
                 cv.Optional(CONF_RESTORE_VALUE, default=False): cv.boolean,
             }
         ),
         cv.Optional(CONF_STANDBY): switch.switch_schema(
-            HuaweiR4850Switch, icon=ICON_POWER
+            HuaweiR4850Switch, icon=ICON_POWER, entity_category=ENTITY_CATEGORY_CONFIG
         ).extend(
             {
                 cv.Optional(CONF_RESTORE_VALUE, default=False): cv.boolean,


### PR DESCRIPTION
This way the various controls appear under separate sections on the device page in Home Assistant. Especially with multiple units connected on the bus the amount of sensors quickly grows out of hand.

See screenshots:
<img width="347" height="385" alt="2026-02-07_13-44_2" src="https://github.com/user-attachments/assets/8f610bff-4c09-465d-9e3a-1d2cddde8074" />
<img width="331" height="558" alt="2026-02-07_13-44_1" src="https://github.com/user-attachments/assets/dd2fe1b1-66f3-4101-9fce-f18e757a2865" />
<img width="337" height="821" alt="2026-02-07_13-44" src="https://github.com/user-attachments/assets/07b12521-b70d-4fcb-b998-68bae187a67f" />
