### PR TITLE
Don't send data requests if CAN bus connectivity broken, add binary sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ ESPHome component to control and read values from Huawei R48xx power supplies vi
 Fork of [mb-software/esphome-huawei-r4850](https://github.com/mb-software/esphome-huawei-r4850).
 
 ## Requirements
-This component is tested and verified to work on ESP32 using the `esp32_can` platform.  
-In addition to the ESP32 board, a CAN transceiver like the SN65HVD230 is required. These can be wired directly to the 3.3V GPIO and supply pins of the ESP32 board.  
+This component is tested and verified to work on ESP32 using the `esp32_can` platform.
+In addition to the ESP32 board, a CAN transceiver like the SN65HVD230 is required. These can be wired directly to the 3.3V GPIO and supply pins of the ESP32 board.
 The component has also been tested with the `mcp2515` platform, but due to ESPHome limits (no interrupts, no TX queue, no RX filtering), it's almost guaranteed sensor updates and control messages will be lost, making it unreliable.
 
 ## Configuration
@@ -44,7 +44,7 @@ huawei_r4850:
 - **update_interval** ([Time](https://esphome.io/guides/configuration-types#config-time), Default `5s`): Update interval for sensors
 - **resend_interval** ([Time](https://esphome.io/guides/configuration-types#config-time), Optional): Interval for numbers and switches to resend their state (so state is consistent even with CAN / PSU disconnects)
 - **psu_address** (int, Required): Address of the PSU (1 = first PSU, 2 = second, ...)
-- **psu_max_current** (float, Default `53.5`): Max current rating of the PSU (~53.5 for R4850G6, ~42.6 for R4830S1).  
+- **psu_max_current** (float, Default `53.5`): Max current rating of the PSU (~53.5 for R4850G6, ~42.6 for R4830S1).
   If `output_current_setpoint` != `max_output_current`, Max current vs. actual current has to be calculated / calibrated.
 
 ### Sensors
@@ -60,7 +60,7 @@ sensor:
     # [...]
 ```
 
-- **huawei_r4850_id**: ID of the main component (required if there are multiple) 
+- **huawei_r4850_id**: ID of the main component (required if there are multiple)
 - **input_voltage**: AC input voltage
 - **input_frequency**: AC input frequency
 - **input_current**: AC input current
@@ -98,7 +98,7 @@ number:
 
 If setting one of these values causes the number input to reset, the value was out of range for the PSU. In that case it makes sense to limit the value range using `min_value` and `max_value` on the number.
 
-- **huawei_r4850_id**: ID of the main component (required if there are multiple) 
+- **huawei_r4850_id**: ID of the main component (required if there are multiple)
 - **output_voltage**: Output voltage
 - **max_output_current**: Output current limit
 - **output_voltage_default**: Default output voltage
@@ -130,10 +130,45 @@ switch:
       name: Fan speed max
 ```
 
-- **huawei_r4850_id**: ID of the main component (required if there are multiple) 
+- **huawei_r4850_id**: ID of the main component (required if there are multiple)
 - **standby**: PSU standby (disables the DC output)
 - **fan_speed_max**: If enabled, forces the fan to full speed (even when the PSU would turn the fan off, which it does when AC input current limit is hit (and set to a low value like 5A) and temperature is <65°C)
 
+### Text sensors
+
+```yaml
+text_sensor:
+  - platform: huawei_r4850
+    huawei_r4850_id: huawei_r4850_1
+    board_type:
+      name: "Board type"
+    serial_number:
+      name: "Serial number"
+    item:
+      name: "Item"
+    # Not all models expose this information
+    #model:
+    #  name: "Model"
+```
+
+- **huawei_r4850_id**: ID of the main component (required if there are multiple)
+- **board_type**: Board-specific information, e.g. "EN1MRF7G1A5"
+- **serial_number**: The device serial number (seen on the sticker, e.g. BT2440636718)
+- **item**: The "item", basically an internal model name (e.g. 02312NFE-002)
+- **model**: The model, e.g. R4875G5 (not always available)
+
+### Binary sensors
+
+```yaml
+binary_sensor:
+  - platform: huawei_r4850
+    huawei_r4850_id: huawei_r4850_1
+    canbus_connectivity:
+      name: "CAN bus connectivity"
+```
+
+- **huawei_r4850_id**: ID of the main component (required if there are multiple)
+- **canbus_connectivity**: Indicates whether the communication on the CAN bus is working. If you have multiple units connected it makes sense to enable this sensor only for one of them.
 
 ### Example config
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ binary_sensor:
 ```
 
 - **huawei_r4850_id**: ID of the main component (required if there are multiple)
-- **canbus_connectivity**: Indicates whether the communication on the CAN bus is working. If you have multiple units connected it makes sense to enable this sensor only for one of them.
+- **canbus_connectivity**: Indicates whether the CAN bus communication with the PSU is working.
 
 ### Example config
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ ESPHome component to control and read values from Huawei R48xx power supplies vi
 Fork of [mb-software/esphome-huawei-r4850](https://github.com/mb-software/esphome-huawei-r4850).
 
 ## Requirements
-This component is tested and verified to work on ESP32 using the `esp32_can` platform.
-In addition to the ESP32 board, a CAN transceiver like the SN65HVD230 is required. These can be wired directly to the 3.3V GPIO and supply pins of the ESP32 board.
+This component is tested and verified to work on ESP32 using the `esp32_can` platform.  
+In addition to the ESP32 board, a CAN transceiver like the SN65HVD230 is required. These can be wired directly to the 3.3V GPIO and supply pins of the ESP32 board.  
 The component has also been tested with the `mcp2515` platform, but due to ESPHome limits (no interrupts, no TX queue, no RX filtering), it's almost guaranteed sensor updates and control messages will be lost, making it unreliable.
 
 ## Configuration
@@ -44,7 +44,7 @@ huawei_r4850:
 - **update_interval** ([Time](https://esphome.io/guides/configuration-types#config-time), Default `5s`): Update interval for sensors
 - **resend_interval** ([Time](https://esphome.io/guides/configuration-types#config-time), Optional): Interval for numbers and switches to resend their state (so state is consistent even with CAN / PSU disconnects)
 - **psu_address** (int, Required): Address of the PSU (1 = first PSU, 2 = second, ...)
-- **psu_max_current** (float, Default `53.5`): Max current rating of the PSU (~53.5 for R4850G6, ~42.6 for R4830S1).
+- **psu_max_current** (float, Default `53.5`): Max current rating of the PSU (~53.5 for R4850G6, ~42.6 for R4830S1).  
   If `output_current_setpoint` != `max_output_current`, Max current vs. actual current has to be calculated / calibrated.
 
 ### Sensors

--- a/components/huawei_r4850/binary_sensor.py
+++ b/components/huawei_r4850/binary_sensor.py
@@ -1,0 +1,31 @@
+import esphome.codegen as cg
+from esphome.components import binary_sensor
+import esphome.config_validation as cv
+from esphome.const import DEVICE_CLASS_CONNECTIVITY, ENTITY_CATEGORY_DIAGNOSTIC
+
+from . import CONF_HUAWEI_R4850_ID, HUAWEI_R4850_COMPONENT_SCHEMA
+
+CONF_CANBUS_CONNECTIVITY = "canbus_connectivity"
+
+BINARY_SENSORS = {
+    CONF_CANBUS_CONNECTIVITY: binary_sensor.binary_sensor_schema(
+        device_class=DEVICE_CLASS_CONNECTIVITY,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+}
+
+CONFIG_SCHEMA = HUAWEI_R4850_COMPONENT_SCHEMA.extend(
+    {
+        cv.Optional(sensor_name): sensor_config
+        for sensor_name, sensor_config in BINARY_SENSORS.items()
+    }
+)
+
+
+async def to_code(config):
+    hub = await cg.get_variable(config[CONF_HUAWEI_R4850_ID])
+    for sensor_name in BINARY_SENSORS:
+        if sensor_name in config:
+            conf = config[sensor_name]
+            sens = await binary_sensor.new_binary_sensor(conf)
+            cg.add(getattr(hub, f"set_{sensor_name}_binary_sensor")(sens))

--- a/components/huawei_r4850/huawei_r4850.cpp
+++ b/components/huawei_r4850/huawei_r4850.cpp
@@ -301,6 +301,7 @@ void HuaweiR4850Component::on_frame(uint32_t can_id, bool extended_id, bool rtr,
       ELabelResponse elabel_response = parse_elabel_response(raw_elabel_response);
       raw_elabel_response.clear();
 
+#ifdef USE_TEXT_SENSOR
       std::map<std::string, text_sensor::TextSensor*> sensor_mappings = {
         {"BoardType", board_type_text_sensor_},
         {"BarCode", serial_number_text_sensor_},
@@ -313,6 +314,7 @@ void HuaweiR4850Component::on_frame(uint32_t can_id, bool extended_id, bool rtr,
           this->publish_sensor_state_(sensor, elabel_response[key].c_str());
         }
       }
+#endif // USE_TEXT_SENSOR
 
       ESP_LOGI(TAG, "Will no longer poll for E-label response");
       has_received_elabel_response_ = true;

--- a/components/huawei_r4850/huawei_r4850.cpp
+++ b/components/huawei_r4850/huawei_r4850.cpp
@@ -347,30 +347,6 @@ void HuaweiR4850Component::on_frame(uint32_t can_id, bool extended_id, bool rtr,
   }
 }
 
-#ifdef USE_SENSOR
-void HuaweiR4850Component::publish_sensor_state_(sensor::Sensor *sensor, float value) {
-  if (sensor) {
-    sensor->publish_state(value);
-  }
-}
-#endif
-
-#ifdef USE_TEXT_SENSOR
-void HuaweiR4850Component::publish_sensor_state_(text_sensor::TextSensor *sensor, const char *state) {
-  if (sensor) {
-    sensor->publish_state(state);
-  }
-}
-#endif // USE_TEXT_SENSOR
-
-#ifdef USE_BINARY_SENSOR
-void HuaweiR4850Component::publish_sensor_state_(binary_sensor::BinarySensor *sensor, bool state) {
-  if (sensor) {
-    sensor->publish_state(state);
-  }
-}
-#endif
-
 uint32_t HuaweiR4850Component::canid_pack_(uint8_t addr, uint8_t command, bool src_controller, bool incomplete) {
   uint32_t id = 0x1080007E; // proto ID, group mask, HW/SW id flag already set
   id |= (uint32_t)(addr & 0x7F) << 16; // 7 bit PSU address (0 = broadcast, 1 = first, ...)

--- a/components/huawei_r4850/huawei_r4850.cpp
+++ b/components/huawei_r4850/huawei_r4850.cpp
@@ -119,7 +119,7 @@ void HuaweiR4850Component::update() {
   // no recent unsolicited messages, mark as bad
   // unsolicited messages should be received every ~377ms.
   // wait at least 500ms to make sure one was actually supposed to arrive.
-  if (canbus_connectivity_ && last_unsolicited_message_ != 0 && (millis() - last_unsolicited_message_ > std::max(update_interval_, 500))) {
+  if (canbus_connectivity_ && last_unsolicited_message_ != 0 && (millis() - last_unsolicited_message_ > std::max<uint32_t>(update_interval_, 500))) {
     canbus_connectivity_ = false;
     ESP_LOGW(TAG, "No unsolicited messages received lately, stopping polling");
 

--- a/components/huawei_r4850/huawei_r4850.cpp
+++ b/components/huawei_r4850/huawei_r4850.cpp
@@ -80,7 +80,7 @@ void HuaweiR4850Component::set_resend_interval(uint32_t interval) {
 }
 
 void HuaweiR4850Component::resend_inputs() {
-  if (this->lastUpdate_ != 0) {
+  if (canbus_connectivity_) {
     for (auto &input : this->registered_inputs_) {
       input->resend_state();
     }
@@ -116,8 +116,16 @@ void HuaweiR4850Component::update() {
   #endif
   }
 
-  // no new value for 5* intervall -> set sensors to NAN)
-  if (this->lastUpdate_ != 0 && (millis() - this->lastUpdate_ > this->update_interval_ * 5)) {
+  // no new unsolicited messages during the last update interval, mark as bad
+  if (canbus_connectivity_ && last_unsolicited_message_ != 0 && (millis() - last_unsolicited_message_ > update_interval_)) {
+    canbus_connectivity_ = false;
+    ESP_LOGW(TAG, "No unsolicited messages received lately, stopping polling");
+
+#ifdef USE_BINARY_SENSOR
+    this->publish_sensor_state_(canbus_connectivity_binary_sensor_, false);
+#endif // USE_BINARY_SENSOR
+
+    // canbus disconnected -> set sensors to NAN
 #ifdef USE_SENSOR
     this->publish_sensor_state_(this->input_power_sensor_, NAN);
     this->publish_sensor_state_(this->input_voltage_sensor_, NAN);
@@ -135,18 +143,6 @@ void HuaweiR4850Component::update() {
     for (auto &input : this->registered_inputs_) {
       input->handle_timeout();
     }
-
-    this->lastUpdate_ = 0; // reset lastUpdate so we don't publish NaN every interval
-  }
-
-  // no new unsolicited messages during the last update interval, mark as bad
-  if (canbus_connectivity_ && last_unsolicited_message_ != 0 && (millis() - last_unsolicited_message_ > update_interval_)) {
-    canbus_connectivity_ = false;
-    ESP_LOGW(TAG, "No unsolicited messages received lately, stopping polling");
-
-#ifdef USE_BINARY_SENSOR
-    this->publish_sensor_state_(canbus_connectivity_binary_sensor_, false);
-#endif // USE_BINARY_SENSOR
   }
 }
 
@@ -266,9 +262,6 @@ void HuaweiR4850Component::on_frame(uint32_t can_id, bool extended_id, bool rtr,
         break;
     }
 #endif // USE_SENSOR
-    if (!incomplete) {
-      this->lastUpdate_ = millis();
-    }
   } else if (cmd == R48xx_CMD_REGISTER_GET) {
 #ifdef USE_SENSOR
     if (error_type == 0) {

--- a/components/huawei_r4850/huawei_r4850.cpp
+++ b/components/huawei_r4850/huawei_r4850.cpp
@@ -89,7 +89,7 @@ void HuaweiR4850Component::resend_inputs() {
 
 void HuaweiR4850Component::update() {
   // Don't bother polling until the bus is determined to be active
-  if (canbus_connectivity) {
+  if (canbus_connectivity_) {
     ESP_LOGD(TAG, "Sending data request message");
     {
       uint32_t canId = this->canid_pack_(this->psu_addr_, R48xx_CMD_DATA, true, false);
@@ -140,8 +140,8 @@ void HuaweiR4850Component::update() {
   }
 
   // no new unsolicited messages during the last update interval, mark as bad
-  if (canbus_connectivity && last_unsolicited_message_ != 0 && (millis() - last_unsolicited_message_ > update_interval_)) {
-    canbus_connectivity = false;
+  if (canbus_connectivity_ && last_unsolicited_message_ != 0 && (millis() - last_unsolicited_message_ > update_interval_)) {
+    canbus_connectivity_ = false;
     ESP_LOGW(TAG, "No unsolicited messages received lately, stopping polling");
 
 #ifdef USE_BINARY_SENSOR
@@ -308,12 +308,12 @@ void HuaweiR4850Component::on_frame(uint32_t can_id, bool extended_id, bool rtr,
   } else if (cmd == R48xx_CMD_ELABEL) {
     // Compose the full response string until complete
     std::vector<uint8_t> data(message.begin() + 2, message.end());
-    raw_elabel_response += std::string(data.cbegin(), data.cend());
+    raw_elabel_response_ += std::string(data.cbegin(), data.cend());
 
     if (!incomplete) {
       ESP_LOGI(TAG, "E-Label response received, populating sensors");
-      ELabelResponse elabel_response = parse_elabel_response(raw_elabel_response);
-      raw_elabel_response.clear();
+      ELabelResponse elabel_response = parse_elabel_response(raw_elabel_response_);
+      raw_elabel_response_.clear();
 
 #ifdef USE_TEXT_SENSOR
       std::map<std::string, text_sensor::TextSensor*> sensor_mappings = {
@@ -336,8 +336,8 @@ void HuaweiR4850Component::on_frame(uint32_t can_id, bool extended_id, bool rtr,
   } else if (cmd == R48xx_CMD_UNSOLICITED) {
     last_unsolicited_message_ = millis();
 
-    if (!canbus_connectivity) {
-      canbus_connectivity = true;
+    if (!canbus_connectivity_) {
+      canbus_connectivity_ = true;
       ESP_LOGI(TAG, "Got unsolicited messages on CAN bus, resuming polling");
 
 #ifdef USE_BINARY_SENSOR

--- a/components/huawei_r4850/huawei_r4850.cpp
+++ b/components/huawei_r4850/huawei_r4850.cpp
@@ -116,8 +116,10 @@ void HuaweiR4850Component::update() {
   #endif
   }
 
-  // no new unsolicited messages during the last update interval, mark as bad
-  if (canbus_connectivity_ && last_unsolicited_message_ != 0 && (millis() - last_unsolicited_message_ > update_interval_)) {
+  // no recent unsolicited messages, mark as bad
+  // unsolicited messages should be received every ~377ms.
+  // wait at least 500ms to make sure one was actually supposed to arrive.
+  if (canbus_connectivity_ && last_unsolicited_message_ != 0 && (millis() - last_unsolicited_message_ > std::max(update_interval_, 500))) {
     canbus_connectivity_ = false;
     ESP_LOGW(TAG, "No unsolicited messages received lately, stopping polling");
 

--- a/components/huawei_r4850/huawei_r4850.h
+++ b/components/huawei_r4850/huawei_r4850.h
@@ -138,11 +138,19 @@ class HuaweiR4850Component : public PollingComponent {
   sensor::Sensor *fan_duty_cycle_target_sensor_{nullptr};
   sensor::Sensor *fan_rpm_sensor_{nullptr};
   bool needs_fan_status_{0};
-  void publish_sensor_state_(sensor::Sensor *sensor, float value);
+  void publish_sensor_state_(sensor::Sensor *sensor, float state) {
+    if (sensor) {
+      sensor->publish_state(state);
+    }
+  }
 #endif // USE_SENSOR
 
 #ifdef USE_TEXT_SENSOR
-  void publish_sensor_state_(text_sensor::TextSensor *sensor, const char *state);
+  void publish_sensor_state_(text_sensor::TextSensor *sensor, const char *state) {
+    if (sensor) {
+      sensor->publish_state(state);
+    }
+  }
 
   text_sensor::TextSensor *board_type_text_sensor_{nullptr};
   text_sensor::TextSensor *serial_number_text_sensor_{nullptr};
@@ -151,7 +159,11 @@ class HuaweiR4850Component : public PollingComponent {
 #endif // USE_TEXT_SENSOR
 
 #ifdef USE_BINARY_SENSOR
-  void publish_sensor_state_(binary_sensor::BinarySensor *sensor, bool value);
+  void publish_sensor_state_(binary_sensor::BinarySensor *sensor, bool state) {
+    if (sensor) {
+      sensor->publish_state(state);
+    }
+  }
 
   binary_sensor::BinarySensor *canbus_connectivity_binary_sensor_{nullptr};
 #endif // USE_BINARY_SENSOR

--- a/components/huawei_r4850/huawei_r4850.h
+++ b/components/huawei_r4850/huawei_r4850.h
@@ -110,6 +110,8 @@ class HuaweiR4850Component : public PollingComponent {
 
   bool has_received_elabel_response_ = false;
   std::string raw_elabel_response;
+  uint32_t last_unsolicited_message_{0};
+  bool canbus_connectivity = false;
 
 #ifdef USE_SENSOR
   sensor::Sensor *input_voltage_sensor_{nullptr};

--- a/components/huawei_r4850/huawei_r4850.h
+++ b/components/huawei_r4850/huawei_r4850.h
@@ -5,6 +5,9 @@
 #ifdef USE_SENSOR
 #include "esphome/components/sensor/sensor.h"
 #endif
+#ifdef USE_BINARY_SENSOR
+#include "esphome/components/binary_sensor/binary_sensor.h"
+#endif
 #ifdef USE_TEXT_SENSOR
 #include "esphome/components/text_sensor/text_sensor.h"
 #endif
@@ -83,6 +86,12 @@ class HuaweiR4850Component : public PollingComponent {
   }
 #endif // USE_TEXT_SENSOR
 
+#ifdef USE_BINARY_SENSOR
+  void set_canbus_connectivity_binary_sensor(binary_sensor::BinarySensor *sensor) {
+    canbus_connectivity_binary_sensor_ = sensor;
+  }
+#endif // USE_BINARY_SENSOR
+
   void register_input(HuaweiR4850Input *number) {
     this->registered_inputs_.push_back(number);
   }
@@ -140,6 +149,12 @@ class HuaweiR4850Component : public PollingComponent {
   text_sensor::TextSensor *item_text_sensor_{nullptr};
   text_sensor::TextSensor *model_text_sensor_{nullptr};
 #endif // USE_TEXT_SENSOR
+
+#ifdef USE_BINARY_SENSOR
+  void publish_sensor_state_(binary_sensor::BinarySensor *sensor, bool value);
+
+  binary_sensor::BinarySensor *canbus_connectivity_binary_sensor_{nullptr};
+#endif // USE_BINARY_SENSOR
 
   std::vector<HuaweiR4850Input *> registered_inputs_{};
 

--- a/components/huawei_r4850/huawei_r4850.h
+++ b/components/huawei_r4850/huawei_r4850.h
@@ -5,7 +5,9 @@
 #ifdef USE_SENSOR
 #include "esphome/components/sensor/sensor.h"
 #endif
+#ifdef USE_TEXT_SENSOR
 #include "esphome/components/text_sensor/text_sensor.h"
+#endif
 #include "esphome/components/canbus/canbus.h"
 
 namespace esphome {

--- a/components/huawei_r4850/huawei_r4850.h
+++ b/components/huawei_r4850/huawei_r4850.h
@@ -113,7 +113,6 @@ class HuaweiR4850Component : public PollingComponent {
 
  protected:
   canbus::Canbus *canbus;
-  uint32_t lastUpdate_{0};
   float psu_max_current_;
   uint8_t psu_addr_;
 

--- a/components/huawei_r4850/huawei_r4850.h
+++ b/components/huawei_r4850/huawei_r4850.h
@@ -122,6 +122,12 @@ class HuaweiR4850Component : public PollingComponent {
   bool canbus_connectivity_ = false;
 
 #ifdef USE_SENSOR
+  void publish_sensor_state_(sensor::Sensor *sensor, float state) {
+    if (sensor) {
+      sensor->publish_state(state);
+    }
+  }
+
   sensor::Sensor *input_voltage_sensor_{nullptr};
   sensor::Sensor *input_frequency_sensor_{nullptr};
   sensor::Sensor *input_current_sensor_{nullptr};
@@ -137,11 +143,6 @@ class HuaweiR4850Component : public PollingComponent {
   sensor::Sensor *fan_duty_cycle_target_sensor_{nullptr};
   sensor::Sensor *fan_rpm_sensor_{nullptr};
   bool needs_fan_status_{0};
-  void publish_sensor_state_(sensor::Sensor *sensor, float state) {
-    if (sensor) {
-      sensor->publish_state(state);
-    }
-  }
 #endif // USE_SENSOR
 
 #ifdef USE_TEXT_SENSOR

--- a/components/huawei_r4850/huawei_r4850.h
+++ b/components/huawei_r4850/huawei_r4850.h
@@ -118,9 +118,9 @@ class HuaweiR4850Component : public PollingComponent {
   uint8_t psu_addr_;
 
   bool has_received_elabel_response_ = false;
-  std::string raw_elabel_response;
+  std::string raw_elabel_response_;
   uint32_t last_unsolicited_message_{0};
-  bool canbus_connectivity = false;
+  bool canbus_connectivity_ = false;
 
 #ifdef USE_SENSOR
   sensor::Sensor *input_voltage_sensor_{nullptr};

--- a/huawei_r4850.yaml
+++ b/huawei_r4850.yaml
@@ -95,3 +95,22 @@ switch:
     huawei_r4850_id: huawei_r4850_1
     standby:
       name: Standby
+
+text_sensor:
+  - platform: huawei_r4850
+    huawei_r4850_id: huawei_r4850_1
+    board_type:
+      name: "Board type"
+    serial_number:
+      name: "Serial number"
+    item:
+      name: "Item"
+    # Not all models expose this information
+    #model:
+    #  name: "Model"
+
+binary_sensor:
+  - platform: huawei_r4850
+    huawei_r4850_id: huawei_r4850_1
+    canbus_connectivity:
+      name: "CAN bus connectivity"


### PR DESCRIPTION
Previously we sent data requests no matter the state of the bus. Since devices send out unsolicited messages regularly when everything is working we can use the presence of those within the last update interval to indicate whether connectivity works.

I added a binary sensor for this as well so people can easily react to communication issues.

Some minor refactoring done too, and fixes for compiling without text sensors. README and examples have also been updated.