### PR TITLE
Read standby state from CAN bus instead of using assumed_state

### DIFF
--- a/components/huawei_r4850/huawei_r4850.cpp
+++ b/components/huawei_r4850/huawei_r4850.cpp
@@ -22,6 +22,8 @@ static const uint8_t R48xx_CMD_CONTROL = 0x80;
 static const uint8_t R48xx_CMD_REGISTER_GET = 0x82;
 static const uint8_t R48xx_CMD_UNSOLICITED = 0x11;
 
+static const uint16_t R48XX_DATA_STATUS1 = 0x001;
+static const uint16_t R48XX_DATA_STANDBY = 0x132;
 static const uint16_t R48xx_DATA_INPUT_POWER = 0x170;
 static const uint16_t R48xx_DATA_INPUT_FREQ = 0x171;
 static const uint16_t R48xx_DATA_INPUT_CURRENT = 0x172;
@@ -338,6 +340,15 @@ void HuaweiR4850Component::on_frame(uint32_t can_id, bool extended_id, bool rtr,
 #ifdef USE_BINARY_SENSOR
       this->publish_sensor_state_(canbus_connectivity_binary_sensor_, true);
 #endif // USE_BINARY_SENSOR
+    }
+
+    // Standby state is sent regularly through unsolicited messages. We use
+    // this to tell the standby switch what its status should be.
+    if (register_id == R48XX_DATA_STATUS1) {
+      for (auto &input : this->registered_inputs_) {
+        std::vector<uint8_t> data = {0x00, message[3], 0x00, 0x00, 0x00, 0x00};
+        input->handle_update(R48XX_DATA_STANDBY, data);
+      }
     }
   }
 }

--- a/components/huawei_r4850/switch/huawei_r4850_switch.cpp
+++ b/components/huawei_r4850/switch/huawei_r4850_switch.cpp
@@ -38,29 +38,19 @@ void HuaweiR4850Switch::resend_state() {
   }
 }
 
-bool HuaweiR4850Switch::assumed_state() {
-  // if we could set the value to "unknown" we wouldn't need this, but we can't
-  // so we just tell HA we don't know the state.
-  return this->assumed_state_;
-}
-
 void HuaweiR4850Switch::handle_update(uint16_t register_id, std::vector<uint8_t> &data) {
   if (register_id != this->registerId_)
     return;
+
   this->publish_state(data[1]);
-  this->assumed_state_ = false;
 }
+
 void HuaweiR4850Switch::handle_error(uint16_t register_id, std::vector<uint8_t> &data) {
-  if (register_id != this->registerId_)
-    return;
-  // we should set the state to "unknown" here, but ESPHome doesn't have a way to do that (for switch entities).
-  this->assumed_state_ = true;
+
 }
+
 void HuaweiR4850Switch::handle_timeout() {
-  // we should set the state to "unavailable" here, but ESPHome doesn't have a way to do that:
-  // https://github.com/esphome/feature-requests/issues/1568
-  // and there isn't a way to set it to "unknown" either.
-  this->assumed_state_ = true;
+
 }
 
 }  // namespace huawei_r4850

--- a/components/huawei_r4850/switch/huawei_r4850_switch.h
+++ b/components/huawei_r4850/switch/huawei_r4850_switch.h
@@ -30,12 +30,9 @@ class HuaweiR4850Switch : public switch_::Switch, public Component, public Huawe
   std::optional<bool> last_state_;
   bool restore_value_{false};
 
-  bool assumed_state_{true};
-
   void send_state_(bool value);
 
   void write_state(bool state) override;
-  bool assumed_state() override;
 
   ESPPreferenceObject pref_;
 };


### PR DESCRIPTION
This makes the standby toggle show up as an actual toggle in Home Assistant and the ESPhome web interface.

<img width="522" height="196" alt="image" src="https://github.com/user-attachments/assets/8b5164a9-5cc4-4e80-b164-5f787ff9057c" />

Only minor caveat to this is that when toggling standby _off_, the toggle flips back for a little while until the unit actually becomes ready again. I think it's better than the previous behavior though.